### PR TITLE
Fix binding for ModalFooter to wrong component

### DIFF
--- a/src/BsReactstrap__ModalFooter.re
+++ b/src/BsReactstrap__ModalFooter.re
@@ -1,39 +1,21 @@
 [@bs.module "reactstrap"] [@react.component]
 external make:
   (
-    ~active: bool=?,
-    ~block: bool=?,
-    ~color: string=?,
-    ~disabled: bool=?,
-    ~outline: bool=?,
     ~tag: 'a=?,
-    ~id: string=?,
-    ~innerRef: 'b=?,
-    ~onClick: 'c=?,
-    ~size: string=?,
     ~className: string=?,
-    ~cssModule: 'd=?,
+    ~cssModule: 'b=?,
     ~children: React.element,
     unit
   ) =>
   React.element =
-  "Button";
+  "ModalFooter";
 
 module Jsx2 = {
   let component = ReasonReact.statelessComponent(__MODULE__);
 
   let make =
       (
-        ~active=?,
-        ~block=?,
-        ~color=?,
-        ~disabled=?,
-        ~outline=?,
         ~tag=?,
-        ~id=?,
-        ~innerRef=?,
-        ~onClick=?,
-        ~size=?,
         ~className=?,
         ~cssModule=?,
         children,
@@ -42,16 +24,7 @@ module Jsx2 = {
     ReasonReactCompat.wrapReactForReasonReact(
       make,
       makeProps(
-        ~active?,
-        ~block?,
-        ~color?,
-        ~disabled?,
-        ~outline?,
         ~tag?,
-        ~id?,
-        ~innerRef?,
-        ~onClick?,
-        ~size?,
         ~className?,
         ~cssModule?,
         ~children,


### PR DESCRIPTION
Binding for ModalFooter use wrong component, should bind to ModalFooter instead of Button.