### PR TITLE
JSX3: Make children optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahrefs/bs-reactstrap",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Bucklescript bindings for Reactstrap",
   "homepage": "https://github.com/ahrefs/bs-reactstrap#readme",
   "repository": "git@github.com:ahrefs/bs-reactstrap.git",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "reasonml"
   ],
   "devDependencies": {
-    "bs-platform": "^5.0.3"
+    "bs-platform": "^5.0.3",
+    "reason-react": "^0.7.0"
   },
   "dependencies": {
     "reactstrap": "^5.0.0"

--- a/src/BsReactstrap__Alert.re
+++ b/src/BsReactstrap__Alert.re
@@ -10,7 +10,7 @@ external make:
     ~toggle: 'b=?,
     ~tag: 'c=?,
     ~transition: 'd=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Badge.re
+++ b/src/BsReactstrap__Badge.re
@@ -6,7 +6,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Breadcrumb.re
+++ b/src/BsReactstrap__Breadcrumb.re
@@ -6,7 +6,7 @@ external make:
     ~className: string=?,
     ~listClassName: string=?,
     ~cssModule: 'c=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__BreadcrumbItem.re
+++ b/src/BsReactstrap__BreadcrumbItem.re
@@ -5,7 +5,7 @@ external make:
     ~active: bool=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Button.re
+++ b/src/BsReactstrap__Button.re
@@ -13,7 +13,7 @@ external make:
     ~size: string=?,
     ~className: string=?,
     ~cssModule: 'd=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__ButtonDropdown.re
+++ b/src/BsReactstrap__ButtonDropdown.re
@@ -14,7 +14,7 @@ external make:
     ~className: string=?,
     ~cssModule: 'e=?,
     ~inNavbar: bool=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__ButtonGroup.re
+++ b/src/BsReactstrap__ButtonGroup.re
@@ -8,7 +8,7 @@ external make:
     ~role: string=?,
     ~size: string=?,
     ~vertical: bool=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__ButtonToolbar.re
+++ b/src/BsReactstrap__ButtonToolbar.re
@@ -6,7 +6,7 @@ external make:
     ~className: string=?,
     ~cssModule: 'b=?,
     ~role: string=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Card.re
+++ b/src/BsReactstrap__Card.re
@@ -9,7 +9,7 @@ external make:
     ~outline: bool=?,
     ~className: string=?,
     ~cssModule: 'c=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__CardBody.re
+++ b/src/BsReactstrap__CardBody.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__CardColumns.re
+++ b/src/BsReactstrap__CardColumns.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__CardDeck.re
+++ b/src/BsReactstrap__CardDeck.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__CardFooter.re
+++ b/src/BsReactstrap__CardFooter.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__CardGroup.re
+++ b/src/BsReactstrap__CardGroup.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__CardHeader.re
+++ b/src/BsReactstrap__CardHeader.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__CardImg.re
+++ b/src/BsReactstrap__CardImg.re
@@ -7,7 +7,7 @@ external make:
     ~className: string=?,
     ~cssModule: 'b=?,
     ~src: string=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__CardImgOverlay.re
+++ b/src/BsReactstrap__CardImgOverlay.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__CardLink.re
+++ b/src/BsReactstrap__CardLink.re
@@ -5,7 +5,7 @@ external make:
     ~innerRef: 'b=?,
     ~className: string=?,
     ~cssModule: 'c=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__CardSubtitle.re
+++ b/src/BsReactstrap__CardSubtitle.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__CardText.re
+++ b/src/BsReactstrap__CardText.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__CardTitle.re
+++ b/src/BsReactstrap__CardTitle.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Col.re
+++ b/src/BsReactstrap__Col.re
@@ -10,7 +10,7 @@ external make:
     ~className: string=?,
     ~cssModule: 'g=?,
     ~widths: 'h=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Collapse.re
+++ b/src/BsReactstrap__Collapse.re
@@ -6,7 +6,7 @@ external make:
     ~className: 'b=?,
     ~navbar: bool=?,
     ~cssModule: 'c=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Container.re
+++ b/src/BsReactstrap__Container.re
@@ -5,7 +5,7 @@ external make:
     ~fluid: bool=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Dropdown.re
+++ b/src/BsReactstrap__Dropdown.re
@@ -15,7 +15,7 @@ external make:
     ~className: string=?,
     ~cssModule: 'e=?,
     ~inNavbar: bool=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__DropdownItem.re
+++ b/src/BsReactstrap__DropdownItem.re
@@ -10,7 +10,7 @@ external make:
     ~className: string=?,
     ~cssModule: 'c=?,
     ~toggle: bool=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__DropdownMenu.re
+++ b/src/BsReactstrap__DropdownMenu.re
@@ -7,7 +7,7 @@ external make:
     ~modifiers: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__DropdownToggle.re
+++ b/src/BsReactstrap__DropdownToggle.re
@@ -11,7 +11,7 @@ external make:
     ~split: bool=?,
     ~tag: 'c=?,
     ~nav: bool=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Fade.re
+++ b/src/BsReactstrap__Fade.re
@@ -6,7 +6,7 @@ external make:
     ~baseClassActive: string=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Form.re
+++ b/src/BsReactstrap__Form.re
@@ -7,7 +7,7 @@ external make:
     ~innerRef: 'b=?,
     ~className: string=?,
     ~cssModule: 'c=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__FormFeedback.re
+++ b/src/BsReactstrap__FormFeedback.re
@@ -5,7 +5,7 @@ external make:
     ~className: string=?,
     ~cssModule: 'a=?,
     ~valid: bool=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__FormGroup.re
+++ b/src/BsReactstrap__FormGroup.re
@@ -8,7 +8,7 @@ external make:
     ~tag: string=?,
     ~className: string=?,
     ~cssModule: 'a=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__FormText.re
+++ b/src/BsReactstrap__FormText.re
@@ -6,7 +6,7 @@ external make:
     ~color: string=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Input.re
+++ b/src/BsReactstrap__Input.re
@@ -25,7 +25,7 @@ external make:
     ~className: string=?,
     ~cssModule: 'e=?,
     ~readOnly: bool=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__InputGroup.re
+++ b/src/BsReactstrap__InputGroup.re
@@ -5,7 +5,7 @@ external make:
     ~size: string=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__InputGroupAddon.re
+++ b/src/BsReactstrap__InputGroupAddon.re
@@ -5,7 +5,7 @@ external make:
     ~addonType: 'a,
     ~className: string=?,
     ~cssModule: 'd=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =
@@ -17,7 +17,7 @@ module Jsx2 = {
   let make =
       (
         ~tag=?,
-        ~addonType=?,
+        ~addonType,
         ~className=?,
         ~cssModule=?,
         children,
@@ -27,7 +27,7 @@ module Jsx2 = {
       make,
       makeProps(
         ~tag?,
-        ~addonType?,
+        ~addonType,
         ~className?,
         ~cssModule?,
         ~children,

--- a/src/BsReactstrap__InputGroupButton.re
+++ b/src/BsReactstrap__InputGroupButton.re
@@ -7,7 +7,7 @@ external make:
     ~groupAttributes: 'c=?,
     ~className: string=?,
     ~cssModule: 'd=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__InputGroupButtonDropdown.re
+++ b/src/BsReactstrap__InputGroupButtonDropdown.re
@@ -1,6 +1,6 @@
 [@bs.module "reactstrap"] [@react.component]
 external make:
-  (~addonType: 'a, ~children: React.element, unit) => React.element =
+  (~addonType: 'a, ~children: React.element=?, unit) => React.element =
   "InputGroupButtonDropdown";
 
 module Jsx2 = {

--- a/src/BsReactstrap__InputGroupText.re
+++ b/src/BsReactstrap__InputGroupText.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Jumbotron.re
+++ b/src/BsReactstrap__Jumbotron.re
@@ -5,7 +5,7 @@ external make:
     ~fluid: bool=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Label.re
+++ b/src/BsReactstrap__Label.re
@@ -14,7 +14,7 @@ external make:
     ~lg: 'e=?,
     ~xl: 'f=?,
     ~widths: 'g=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__ListGroup.re
+++ b/src/BsReactstrap__ListGroup.re
@@ -5,7 +5,7 @@ external make:
     ~flush: bool=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__ListGroupItem.re
+++ b/src/BsReactstrap__ListGroupItem.re
@@ -8,7 +8,7 @@ external make:
     ~action: bool=?,
     ~className: 'b=?,
     ~cssModule: 'c=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__ListGroupItemHeading.re
+++ b/src/BsReactstrap__ListGroupItemHeading.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: 'b=?,
     ~cssModule: 'c=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__ListGroupItemText.re
+++ b/src/BsReactstrap__ListGroupItemText.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: 'b=?,
     ~cssModule: 'c=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Media.re
+++ b/src/BsReactstrap__Media.re
@@ -13,7 +13,7 @@ external make:
     ~right: bool=?,
     ~tag: 'b=?,
     ~top: bool=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Modal.re
+++ b/src/BsReactstrap__Modal.re
@@ -25,7 +25,7 @@ external make:
     ~zIndex: 'i=?,
     ~backdropTransition: 'j=?,
     ~modalTransition: 'k=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__ModalBody.re
+++ b/src/BsReactstrap__ModalBody.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__ModalFooter.re
+++ b/src/BsReactstrap__ModalFooter.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__ModalHeader.re
+++ b/src/BsReactstrap__ModalHeader.re
@@ -7,7 +7,7 @@ external make:
     ~className: string=?,
     ~cssModule: 'd=?,
     ~closeAriaLabel: string=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Nav.re
+++ b/src/BsReactstrap__Nav.re
@@ -12,7 +12,7 @@ external make:
     ~tag: 'b=?,
     ~className: string=?,
     ~cssModule: 'c=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__NavItem.re
+++ b/src/BsReactstrap__NavItem.re
@@ -5,7 +5,7 @@ external make:
     ~active: bool=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__NavLink.re
+++ b/src/BsReactstrap__NavLink.re
@@ -9,7 +9,7 @@ external make:
     ~cssModule: 'c=?,
     ~onClick: 'd=?,
     ~href: 'e=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Navbar.re
+++ b/src/BsReactstrap__Navbar.re
@@ -14,7 +14,7 @@ external make:
     ~cssModule: 'c=?,
     ~toggleable: 'd=?,
     ~expand: 'e=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__NavbarBrand.re
+++ b/src/BsReactstrap__NavbarBrand.re
@@ -5,7 +5,7 @@ external make:
     ~className: string=?,
     ~cssModule: 'b=?,
     ~href: string=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__NavbarToggler.re
+++ b/src/BsReactstrap__NavbarToggler.re
@@ -5,7 +5,7 @@ external make:
     ~_type: string=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Pagination.re
+++ b/src/BsReactstrap__Pagination.re
@@ -5,7 +5,7 @@ external make:
     ~cssModule: 'a=?,
     ~size: string=?,
     ~tag: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__PaginationItem.re
+++ b/src/BsReactstrap__PaginationItem.re
@@ -6,7 +6,7 @@ external make:
     ~cssModule: 'a=?,
     ~disabled: bool=?,
     ~tag: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__PaginationLink.re
+++ b/src/BsReactstrap__PaginationLink.re
@@ -7,7 +7,7 @@ external make:
     ~next: bool=?,
     ~previous: bool=?,
     ~tag: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Popover.re
+++ b/src/BsReactstrap__Popover.re
@@ -14,7 +14,7 @@ external make:
     ~toggle: 'e=?,
     ~delay: 'f=?,
     ~modifiers: 'g=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__PopoverBody.re
+++ b/src/BsReactstrap__PopoverBody.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__PopoverHeader.re
+++ b/src/BsReactstrap__PopoverHeader.re
@@ -4,7 +4,7 @@ external make:
     ~tag: 'a=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__PopperContent.re
+++ b/src/BsReactstrap__PopperContent.re
@@ -14,7 +14,7 @@ external make:
     ~container: 'd=?,
     ~target: 'e,
     ~modifiers: 'f=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Portal.re
+++ b/src/BsReactstrap__Portal.re
@@ -1,5 +1,5 @@
 [@bs.module "reactstrap"] [@react.component]
-external make: (~node: 'a=?, ~children: React.element, unit) => React.element =
+external make: (~node: 'a=?, ~children: React.element=?, unit) => React.element =
   "Portal";
 
 module Jsx2 = {

--- a/src/BsReactstrap__Progress.re
+++ b/src/BsReactstrap__Progress.re
@@ -12,7 +12,7 @@ external make:
     ~className: string=?,
     ~barClassName: string=?,
     ~cssModule: 'c=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Row.re
+++ b/src/BsReactstrap__Row.re
@@ -5,7 +5,7 @@ external make:
     ~noGutters: bool=?,
     ~className: string=?,
     ~cssModule: 'b=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__TabContent.re
+++ b/src/BsReactstrap__TabContent.re
@@ -5,7 +5,7 @@ external make:
     ~activeTab: 'b=?,
     ~className: string=?,
     ~cssModule: 'c=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__TabPane.re
+++ b/src/BsReactstrap__TabPane.re
@@ -5,7 +5,7 @@ external make:
     ~className: string=?,
     ~cssModule: 'b=?,
     ~tabId: 'c=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Table.re
+++ b/src/BsReactstrap__Table.re
@@ -13,7 +13,7 @@ external make:
     ~responsive: 'c=?,
     ~tag: 'd=?,
     ~responsiveTag: 'e=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__Tooltip.re
+++ b/src/BsReactstrap__Tooltip.re
@@ -15,7 +15,7 @@ external make:
     ~placementPrefix: string=?,
     ~delay: 'f=?,
     ~modifiers: 'g=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/src/BsReactstrap__UncontrolledCarousel.re
+++ b/src/BsReactstrap__UncontrolledCarousel.re
@@ -9,7 +9,7 @@ external make:
     ~next: 'c=?,
     ~previous: 'd=?,
     ~goToIndex: 'e=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   React.element =

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,6 +64,11 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 lodash.isfunction@^3.0.9:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
@@ -81,6 +86,13 @@ loose-envify@^1.0.0, loose-envify@^1.3.1:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.1.0, loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -111,6 +123,30 @@ prop-types@^15.5.8, prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
+react-dom@>=16.8.1:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
+
+react-is@^16.8.1:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
 react-popper@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.8.3.tgz#0f73333137c9fb0af6ec4074d2d0585a0a0461e1"
@@ -129,6 +165,16 @@ react-transition-group@^2.2.1:
     prop-types "^15.5.8"
     warning "^3.0.0"
 
+react@>=16.8.1:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
+
 reactstrap@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/reactstrap/-/reactstrap-5.0.0.tgz#d8948534df4816eddfb162a51643a499388e9228"
@@ -140,6 +186,22 @@ reactstrap@^5.0.0:
     prop-types "^15.5.8"
     react-popper "^0.8.3"
     react-transition-group "^2.2.1"
+
+reason-react@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.7.0.tgz#46a975c321e81cd51310d7b1a02418ca7667b0d6"
+  integrity sha512-czR/f0lY5iyLCki9gwftOFF5Zs40l7ZSFmpGK/Z6hx2jBVeFDmIiXB8bAQW/cO6IvtuEt97OmsYueiuOYG9XjQ==
+  dependencies:
+    react ">=16.8.1"
+    react-dom ">=16.8.1"
+
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 setimmediate@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
This changes all `children` props to make them optional in JSX3.

Also:
- Adds `reason-react` as `devDependency` to be able to run the dev build
- Makes `addonType` a non-optional prop in the Jsx2 module of `InputGroupAddon` to avoid warnings on building.